### PR TITLE
fix: don't ignore Maven Wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,3 @@ out/
 
 # VS Code
 .vscode/
-
-# Maven wrapper
-.mvn/
-mvnw


### PR DESCRIPTION
Maven Wrapper is part of generated Hilla applications and should be shared with other developers.